### PR TITLE
Add flex properties for small screen view

### DIFF
--- a/src/features/Landing/Overview.jsx
+++ b/src/features/Landing/Overview.jsx
@@ -20,7 +20,7 @@ export default function Overview() {
         <CloudSvgResource />
         <TextContent
           title="Simple, effortless and intuitive ..."
-          caption="We save your previously used contacts, for easy access"
+          caption="Recently used contacts are automatically populated, for easy access"
         />
       </Stack>
       <Testimonials />

--- a/src/features/Testimonials/Review.jsx
+++ b/src/features/Testimonials/Review.jsx
@@ -37,7 +37,7 @@ const reviews = [
 
 function Review() {
   return (
-    <Stack direction="row" spacing={2} useFlexGap flexGrow={1}>
+    <Stack direction={{ md: 'row', xs: 'column'}} spacing={2} useFlexGap flexGrow={1}>
       {reviews.map((v) => (
         <Card key={v.id} sx={{ borderRadius: "1rem" }}>
           <CardMedia

--- a/src/features/Testimonials/Testimonials.jsx
+++ b/src/features/Testimonials/Testimonials.jsx
@@ -6,9 +6,7 @@ import TextContent from "../Landing/TextContent";
 function Testimonials() {
   return (
     <Stack spacing={1} textAlign="center">
-      <TextContent
-        title="Check out what our users have to say ..."
-      />
+      <TextContent title="Check out what our users have to say ..." />
       <Review />
     </Stack>
   );


### PR DESCRIPTION
In small screen, the testimonials section was not building correctly. Added flex properties to support proper display of testimonials.

# Screenshots / Visuals

![image](https://github.com/user-attachments/assets/dc03bef8-4d45-417f-9559-381ace4b35f5)
![image](https://github.com/user-attachments/assets/5830f106-30ad-434b-ac2c-399c182d4c52)
